### PR TITLE
Update README with Codex integration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Basic NumPy Example
 
-This repository contains a small Jupyter Notebook demonstrating the basics of using NumPy.
+This repository is a sample for verifying integration with OpenAI Codex.
+このリポジトリは OpenAI Codex との連携検証を目的としたサンプルです。
+
+This repository contains a small Jupyter Notebook demonstrating the basics of
+using NumPy.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- mention Codex integration purpose at the top of README
- keep README formatting with both English and Japanese lines

## Testing
- `markdownlint README.md`
- `codespell README.md`
- `python numpy_basic.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68634035020c8331afaa628e1887654d